### PR TITLE
Undo change to logged_in? method to fix error

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,7 +12,7 @@ class ApplicationController < ActionController::Base
   end
 
   def logged_in?
-    !!session[:uid]
+    current_user != nil
   end
 
 end


### PR DESCRIPTION
Undid previous change to logged_in? method, which now renders an error when current_user is called on the root page.
