### PR TITLE
Update visibility logic on collections show view.

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -10,16 +10,16 @@
     </div>
     <% if has_pending_observations?(@collection) %>
       <h5 class="center-text">You have pending observations to approve for this collection.</h5>
-        <% @collection.pending_observations.each do |o|%>
-              <li class= "center-pic"><%= link_to (image_tag o.image.url(:medium)), collection_observation_path(@collection, o) %></li>
-              <li class= "center-text"><span><em><%= o.description %></span></em><li>
-              <li class= "center-text"><span>PENDING. Pitched by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
-              <li class= "center-text"><%= button_to "Approve", collection_observation_path(@collection, o), :method => :put, class: "radius small button info" %><li>
-              <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
-        <% end %>
+      <% @collection.pending_observations.each do |o|%>
+        <li class= "center-pic"><%= link_to (image_tag o.image.url(:medium)), collection_observation_path(@collection, o) %></li>
+        <li class= "center-text"><span><em><%= o.description %></span></em><li>
+        <li class= "center-text"><span>PENDING. Pitched by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+        <li class= "center-text"><%= button_to "Approve", collection_observation_path(@collection, o), :method => :put, class: "radius small button info" %><li>
+        <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
+      <% end %>
     <% end %>
   <% end %>
-      <% @collection.approved_observations.each do |o|%>
+  <% @collection.approved_observations.each do |o|%>
     <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
     <li class= "center-text"><span><em><%= o.description %></span></em><li>
     <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
@@ -27,7 +27,14 @@
       <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
     <% end %>
   <%end%>
-
+<% else %>
+  <% if @collection.observations.first %>
+    <% @collection.observations.each do |o|%>
+      <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
+      <li class= "center-text"><span><em><%= o.description %></span></em><li>
+      <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+    <%end%>
+  <%end%>
 <% end %>
 
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -27,6 +27,8 @@
         <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
       <% end %>
     <%end%>
+  <% else %>
+    <h2>This is a private collection. Only users with viewing permission can view.</h2>
   <%end%>
 <% else %>
   <% if @collection.public? %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,4 +1,3 @@
-
 <div class = "content">
   <h2 class = "center-text"><%= @collection.title  %></h2>
   <div class = "center-text">Share these spottings:<%= social_share_button_tag("Check out what I spotted: #{@collection.title}") %></div>
@@ -19,21 +18,27 @@
       <% end %>
     <% end %>
   <% end %>
-  <% @collection.approved_observations.each do |o|%>
-    <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
-    <li class= "center-text"><span><em><%= o.description %></span></em><li>
-    <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
-    <% if belongs_to_current_user?(o) || belongs_to_current_user?(@collection) %>
-      <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
-    <% end %>
-  <%end%>
-<% else %>
-  <% if @collection.observations.first %>
-    <% @collection.observations.each do |o|%>
+  <% if @collection.visible_to_user?(current_user) %>
+    <% @collection.approved_observations.each do |o|%>
       <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
       <li class= "center-text"><span><em><%= o.description %></span></em><li>
       <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+      <% if belongs_to_current_user?(o) || belongs_to_current_user?(@collection) %>
+        <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
+      <% end %>
     <%end%>
+  <%end%>
+<% else %>
+  <% if @collection.public? %>
+    <% if @collection.observations.first %>
+      <% @collection.observations.each do |o|%>
+        <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
+        <li class= "center-text"><span><em><%= o.description %></span></em><li>
+        <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+      <%end%>
+    <%end%>
+  <% else %>
+    <h2>This is a private collection. Only logged in users with viewing permission can view.</h2>
   <%end%>
 <% end %>
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -3,46 +3,47 @@
   <div class = "center-text">Share these spottings:<%= social_share_button_tag("Check out what I spotted: #{@collection.title}") %></div>
   <div class= "center-text"><%= button_to "Add an Observation", new_collection_observation_path(@collection), method: "get", class: "radius small button"%></div>
 
-<% if logged_in? %>
-  <% if @collection.owned_by?(current_user) %>
-    <div class= "center-text"><%= button_to "Edit Collection Permissions", collection_permissions_path(@collection), method: "get", class: "radius small button alert"%>
-    </div>
-    <% if has_pending_observations?(@collection) %>
-      <h5 class="center-text">You have pending observations to approve for this collection.</h5>
-      <% @collection.pending_observations.each do |o|%>
-        <li class= "center-pic"><%= link_to (image_tag o.image.url(:medium)), collection_observation_path(@collection, o) %></li>
-        <li class= "center-text"><span><em><%= o.description %></span></em><li>
-        <li class= "center-text"><span>PENDING. Pitched by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
-        <li class= "center-text"><%= button_to "Approve", collection_observation_path(@collection, o), :method => :put, class: "radius small button info" %><li>
-        <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
+  <% if logged_in? %>
+    <% if @collection.owned_by?(current_user) %>
+      <div class= "center-text"><%= button_to "Edit Collection Permissions", collection_permissions_path(@collection), method: "get", class: "radius small button alert"%>
+      </div>
+      <% if has_pending_observations?(@collection) %>
+        <h5 class="center-text">You have pending observations to approve for this collection.</h5>
+        <% @collection.pending_observations.each do |o|%>
+          <li class= "center-pic"><%= link_to (image_tag o.image.url(:medium)), collection_observation_path(@collection, o) %></li>
+          <li class= "center-text"><span><em><%= o.description %></span></em><li>
+          <li class= "center-text"><span>PENDING. Pitched by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+          <li class= "center-text"><%= button_to "Approve", collection_observation_path(@collection, o), :method => :put, class: "radius small button info" %><li>
+          <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
-  <% if @collection.visible_to_user?(current_user) %>
-    <% @collection.approved_observations.each do |o|%>
-      <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
-      <li class= "center-text"><span><em><%= o.description %></span></em><li>
-      <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
-      <% if belongs_to_current_user?(o) || belongs_to_current_user?(@collection) %>
-        <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
-      <% end %>
-    <%end%>
-  <% else %>
-    <h2>This is a private collection. Only users with viewing permission can view.</h2>
-  <%end%>
-<% else %>
-  <% if @collection.public? %>
-    <% if @collection.observations.first %>
-      <% @collection.observations.each do |o|%>
+    <% if @collection.visible_to_user?(current_user) %>
+      <% @collection.approved_observations.each do |o|%>
         <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
         <li class= "center-text"><span><em><%= o.description %></span></em><li>
         <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+        <% if belongs_to_current_user?(o) || belongs_to_current_user?(@collection) %>
+          <div id = "delete-observe"><li class= "center-text"><%= button_to "Delete", collection_observation_path(@collection, o), :method => :delete, class: "radius small button alert" %><li></div>
+        <% end %>
       <%end%>
+    <% else %>
+      <h2>This is a private collection. Only users with viewing permission can view.</h2>
     <%end%>
   <% else %>
-    <h2>This is a private collection. Only logged in users with viewing permission can view.</h2>
-  <%end%>
-<% end %>
+    <% if @collection.public? %>
+      <% if @collection.observations.first %>
+        <% @collection.observations.each do |o|%>
+          <li class= "center-pic"><%= image_tag o.image.url(:medium)  %></li>
+          <li class= "center-text"><span><em><%= o.description %></span></em><li>
+          <li class= "center-text"><span>Added by <%= link_to o.curator.name, curator_path(o.curator) %></span><li>
+        <%end%>
+      <%end%>
+    <% else %>
+      <h2>This is a private collection. Only logged in users with viewing permission can view.</h2>
+    <%end%>
+  <% end %>
+</div>
 
 
 


### PR DESCRIPTION
With this update:

Not logged in users:
-Can see the observations in public collections
-Cannot see any other collections on index page, or on show page (even if they hard code url into browswer)

Logged in users:
-Can see private collections that they have access to see
-Cannot see private collections that they do not have access to see
-Can see public collections
