### PR TITLE
Rename observations to sightings

### DIFF
--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,14 +1,14 @@
 <div class = "content">
   <h2 class = "center-text"><%= @collection.title  %></h2>
   <div class = "center-text">Share these spottings:<%= social_share_button_tag("Check out what I spotted: #{@collection.title}") %></div>
-  <div class= "center-text"><%= button_to "Add an Observation", new_collection_observation_path(@collection), method: "get", class: "radius small button"%></div>
+  <div class= "center-text"><%= button_to "Add a Sighting", new_collection_observation_path(@collection), method: "get", class: "radius small button"%></div>
 
   <% if logged_in? %>
     <% if @collection.owned_by?(current_user) %>
       <div class= "center-text"><%= button_to "Edit Collection Permissions", collection_permissions_path(@collection), method: "get", class: "radius small button alert"%>
       </div>
       <% if has_pending_observations?(@collection) %>
-        <h5 class="center-text">You have pending observations to approve for this collection.</h5>
+        <h5 class="center-text">You have pending sightings to approve for this collection.</h5>
         <% @collection.pending_observations.each do |o|%>
           <li class= "center-pic"><%= link_to (image_tag o.image.url(:medium)), collection_observation_path(@collection, o) %></li>
           <li class= "center-text"><span><em><%= o.description %></span></em><li>

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -9,4 +9,4 @@
 
 </ul>
 
-<%= button_to "Add Observations", new_collection_observation, method: "get" %>
+<%= button_to "Add Sightings", new_collection_observation, method: "get" %>

--- a/app/views/observations/new.html.erb
+++ b/app/views/observations/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="form">
 <% if logged_in? %>
-  <h2 class = "center-text">New Observation</h2>
+  <h2 class = "center-text">New Sighting</h2>
 
   <%= form_for @observation, url: collection_observations_path(@collection),  html: { multipart: true } do |f|%>
   <div class="3 columns">
@@ -18,7 +18,7 @@
       <%= f.hidden_field :curator_id, value: current_user.id %>
       <% if current_user_can_add?(@collection) %>
         <%= f.hidden_field :pending, value: false %>
-        <div class = "center-text"><%= f.submit "Add Observation", class: "radius success large button" %></div>
+        <div class = "center-text"><%= f.submit "Add Sighting", class: "radius success large button" %></div>
       <% else %>
         <%= f.hidden_field :pending, value: true %>
         <div class = "center-text"><%= f.submit "Pitch to #{@collection.curator.name}'s Collection", class: "radius success medium button" %></div>
@@ -26,7 +26,7 @@
   <% end %>
 
 <% else %>
-  <h2><%= link_to 'Log in', login_path %> to add an observation.</h2>
+  <h2><%= link_to 'Log in', login_path %> to add a sighting.</h2>
 <% end %>
 </div>
 


### PR DESCRIPTION
All user-visible references to "observation" or "observations" are changed to "sighting" or "sightings".
