### PR TITLE
Dry show_all view

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,7 +1,18 @@
 module ViewHelper
-
   def belongs_to_current_user?(object)
     current_user == object.curator
   end
 
+  def collection_image?(coll)
+    if coll.approved_observations.last
+      if coll.approved_observations.last.image_file_name.present?
+        return true
+      end
+    end
+    return false
+  end
+
+  def collection_thumb_image(coll)
+    coll.observations.last.image.url(:thumb)
+  end
 end

--- a/app/views/collections/_show_all.html.erb
+++ b/app/views/collections/_show_all.html.erb
@@ -2,19 +2,21 @@
   <% collections.each do |c| %>
     <% if c.visible_to_user?(current_user) %>
       <div class="large-4 small-6 columns">
-        <% if c.observations.last && c.observations.last.image_file_name.present?%>
-          <% if c.observations.last.approved? %>
-            <div class = "image-thumb"><%= link_to (image_tag c.observations.last.image.url(:thumb)), collection_path(c) %></div>
+        <% if c.observations.last %>
+          <% if c.observations.last.image_file_name.present? %>
+            <% if c.observations.last.approved? %>
+              <div class = "image-thumb"><%= link_to (image_tag c.observations.last.image.url(:thumb)), collection_path(c) %></div>
+            <% else %>
+              <div class = "image-thumb"><%= link_to (image_tag c.observations[-2].image.url(:thumb)), collection_path(c) %></div>
+            <% end %>
           <% else %>
-             <div class = "image-thumb"><%= link_to (image_tag c.observations[-2].image.url(:thumb)), collection_path(c) %></div>
+            <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
           <% end %>
-        <% else %>
-          <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
-        <% end %>
-        <div class="category-info">
-          <h5><%= link_to c.title, collection_path(c)%></h5>
-          <h6 class="subheader"><%=c.curator.public_name%></h6>
-        </div>
+          <div class="category-info">
+            <h5><%= link_to c.title, collection_path(c)%></h5>
+            <h6 class="subheader"><%=c.curator.public_name%></h6>
+          </div>
+        <%end%>
       </div>
     <%end%>
   <%end%>
@@ -39,9 +41,3 @@
     <%end%>
   <%end%>
 <%end%>
-
-
-
-
-
-

--- a/app/views/collections/_show_all.html.erb
+++ b/app/views/collections/_show_all.html.erb
@@ -1,35 +1,25 @@
 <% if logged_in? %>
   <% collections.each do |c| %>
-    <% if c.visible_to_user?(current_user) %>
-      <div class="large-4 small-6 columns">
-        <% if c.observations.last %>
-          <% if c.observations.last.image_file_name.present? %>
-            <% if c.observations.last.approved? %>
-              <div class = "image-thumb"><%= link_to (image_tag c.observations.last.image.url(:thumb)), collection_path(c) %></div>
-            <% else %>
-              <div class = "image-thumb"><%= link_to (image_tag c.observations[-2].image.url(:thumb)), collection_path(c) %></div>
-            <% end %>
-          <% else %>
+    <div class="large-4 small-6 columns">
+      <% if c.visible_to_user?(current_user) %>
+        <% if collection_image?(c) %>
+            <div class = "image-thumb"><%= link_to (image_tag collection_thumb_image(c)), collection_path(c) %></div>
+        <% else %>
             <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
-          <% end %>
-          <div class="category-info">
-            <h5><%= link_to c.title, collection_path(c)%></h5>
-            <h6 class="subheader"><%=c.curator.public_name%></h6>
-          </div>
-        <%end%>
-      </div>
-    <%end%>
+        <% end %>
+        <div class="category-info">
+          <h5><%= link_to c.title, collection_path(c)%></h5>
+          <h6 class="subheader"><%=c.curator.public_name%></h6>
+        </div>
+      <%end%>
+    </div>
   <%end%>
 <% else %>
   <% collections.each do |c| %>
-    <% if c.public? %>
-      <div class="large-4 small-6 columns">
-        <% if c.observations.last && c.observations.last.image_file_name.present?%>
-            <% if c.observations.last.approved? %>
-              <div class = "image-thumb"><%= link_to (image_tag c.observations.last.image.url(:thumb)), collection_path(c) %></div>
-            <% else %>
-               <div class = "image-thumb"><%= link_to (image_tag c.observations[-2].image.url(:thumb)), collection_path(c) %></div>
-            <% end %>
+    <div class="large-4 small-6 columns">
+      <% if c.public? %>
+        <% if collection_image?(c) %>
+          <div class = "image-thumb"><%= link_to (image_tag collection_thumb_image(c)), collection_path(c) %></div>
         <% else %>
           <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
         <% end %>
@@ -37,7 +27,7 @@
           <h5><%= link_to c.title, collection_path(c)%></h5>
           <h6 class="subheader"><%=c.curator.public_name%></h6>
         </div>
-      </div>
-    <%end%>
+      <%end%>
+    </div>
   <%end%>
 <%end%>

--- a/app/views/collections/_show_all.html.erb
+++ b/app/views/collections/_show_all.html.erb
@@ -2,15 +2,7 @@
   <% collections.each do |c| %>
     <div class="large-4 small-6 columns">
       <% if c.visible_to_user?(current_user) %>
-        <% if collection_image?(c) %>
-            <div class = "image-thumb"><%= link_to (image_tag collection_thumb_image(c)), collection_path(c) %></div>
-        <% else %>
-            <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
-        <% end %>
-        <div class="category-info">
-          <h5><%= link_to c.title, collection_path(c)%></h5>
-          <h6 class="subheader"><%=c.curator.public_name%></h6>
-        </div>
+        <%= render partial: 'thumbsize_collection', locals: { c: c } %>
       <%end%>
     </div>
   <%end%>
@@ -18,15 +10,7 @@
   <% collections.each do |c| %>
     <div class="large-4 small-6 columns">
       <% if c.public? %>
-        <% if collection_image?(c) %>
-          <div class = "image-thumb"><%= link_to (image_tag collection_thumb_image(c)), collection_path(c) %></div>
-        <% else %>
-          <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
-        <% end %>
-        <div class="category-info">
-          <h5><%= link_to c.title, collection_path(c)%></h5>
-          <h6 class="subheader"><%=c.curator.public_name%></h6>
-        </div>
+        <%= render partial: 'thumbsize_collection', locals: { c: c } %>
       <%end%>
     </div>
   <%end%>

--- a/app/views/collections/_thumbsize_collection.html.erb
+++ b/app/views/collections/_thumbsize_collection.html.erb
@@ -1,0 +1,9 @@
+<% if collection_image?(c) %>
+  <div class = "image-thumb"><%= link_to (image_tag collection_thumb_image(c)), collection_path(c) %></div>
+<% else %>
+  <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
+<% end %>
+<div class="category-info">
+  <h5><%= link_to c.title, collection_path(c)%></h5>
+  <h6 class="subheader"><%=c.curator.public_name%></h6>
+</div>


### PR DESCRIPTION
DRY the show_all view:

-Logic for collection profile image existence and path name has been moved to view helper.

-Create partial for thumb-size collection rendering, which is called from show_all view.
