### PR TITLE
Limit title length on show_all views

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -41,4 +41,13 @@ class Collection < ActiveRecord::Base
     self.public? || self.owned_by?(user)
   end
 
+  def shortened_title
+    title = self.title
+    if title.length > 22
+      return title[0..21] + "..."
+    else
+      return title
+    end
+  end
+
 end

--- a/app/views/collections/_show_all_profile.html.erb
+++ b/app/views/collections/_show_all_profile.html.erb
@@ -12,7 +12,7 @@
       <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
       <% end %>
           <div class="category-info">
-          <h5><%= link_to c.title, collection_path(c)%></h5>
+          <h5><%= link_to c.shortened_title, collection_path(c)%></h5>
           <h6 class="subheader"><%=c.curator.public_name%></h6>
           <div class="subheader">
             <% if belongs_to_current_user?(c) %>
@@ -42,7 +42,7 @@
           <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
       <% end %>
           <div class="category-info">
-          <h5><%= link_to c.title, collection_path(c)%></h5>
+          <h5><%= link_to c.shortened_title, collection_path(c)%></h5>
           <h6 class="subheader"><%=c.curator.public_name%></h6>
         </div>
         </div>

--- a/app/views/collections/_thumbsize_collection.html.erb
+++ b/app/views/collections/_thumbsize_collection.html.erb
@@ -4,6 +4,6 @@
   <div class = "image-thumb"><%= link_to (image_tag 'blank.png'), collection_path(c) %></div>
 <% end %>
 <div class="category-info">
-  <h5><%= link_to c.title, collection_path(c)%></h5>
+  <h5><%= link_to c.shortened_title, collection_path(c)%></h5>
   <h6 class="subheader"><%=c.curator.public_name%></h6>
 </div>


### PR DESCRIPTION
Limits title length on both show_all views, to avoid display issues from titles that are too long. Limits title to 25 characters, adds "..." to titles over 22 characters.
