### PR TITLE
Securify the app

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -57,13 +57,18 @@ class CollectionsController < ApplicationController
 
   def update
     @collection = Collection.find(params[:id])
-    @collection.update_attributes(valid_params)
-    if @collection.save
+    if @collection.owned_by?(current_user)
+      if @collection.update_attributes(valid_params)
+       redirect_to collection_permissions_path(@collection)
+       flash[:notice] = "Update successful!"
+      else
+        flash[:errors] = "Collection update failed. Please try again. Note: only owner of collection can update it."
+        redirect_to collection_permissions_path(@collection)
+      end
     else
-      flash[:errors] = "Collection cannot be saved!"
-      redirect_to root_path
+      flash[:error] = "You are not authorized to edit this collection"
+      redirect_to collection_path(@collection)
     end
-    redirect_to collection_permissions_path(@collection)
   end
 
   def index

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -40,10 +40,15 @@ class CollectionsController < ApplicationController
   def destroy
     session[:return_to] ||= request.referer
     collection = Collection.find(params[:id])
-    collection.observations.delete_all
-    collection.roles.delete_all
-    collection.destroy
-    redirect_to collections_path
+    if collection.owned_by?(current_user)
+      collection.observations.delete_all
+      collection.roles.delete_all
+      collection.destroy
+      redirect_to collections_path
+    else
+      flash[:error] = "You are not authorized to delete this collection"
+      redirect_to collection_path(collection)
+    end
   end
 
   def edit

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -40,15 +40,23 @@
   def update
     collection = Collection.find(params[:collection_id])
     observation = Observation.find(params[:id])
-    observation.pending = false
-    observation.update_attributes(observation_params)
-    observation.save
+    if collection.owned_by?(current_user)
+      observation.pending = false
+      observation.update_attributes(observation_params)
+      observation.save
+    else
+      flash[:error] = "You are not authorized to update sightings on this collection"
+    end
     redirect_to collection_path(collection)
   end
 
   def destroy
     collection = Collection.find(params[:collection_id ])
-    Observation.find(params[:id]).destroy
+    if collection.owned_by?(current_user)
+      Observation.find(params[:id]).destroy
+    else
+      flash[:error] = "You are not authorized to delete sightings on this collection"
+    end
     redirect_to collection_path(collection)
   end
 

--- a/app/views/collections/permissions.html.erb
+++ b/app/views/collections/permissions.html.erb
@@ -1,3 +1,5 @@
+<%= flash[:errors] %>
+<%= flash[:notice] %>
 <div class= "content">
   <% if @collection.owned_by?(current_user) %>
       <h2 class = "center-text">Settings</h2>


### PR DESCRIPTION
Secures the update and destroy actions on the collections and observations controllers, so updates and destroys can only be done if current user is owner of corresponding collection. (Note: curators controller had already been secured.)
