### PR TITLE
Fix bugs with observations

### DIFF
--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -14,6 +14,7 @@
   def create
     collection = Collection.find(params[:collection_id])
     observation = collection.observations.build(observation_params)
+    observation.curator_id = current_user.id
     if observation.save
       if collection.user_can_add?(current_user)
         observation.pending = false
@@ -52,8 +53,9 @@
 
   def destroy
     @collection = Collection.find(params[:collection_id ])
-    if @collection.owned_by?(current_user)
-      Observation.find(params[:id]).destroy
+    observation = Observation.find(params[:id])
+    if @collection.owned_by?(current_user) || observation.owned_by?(current_user)
+      observation.destroy
     else
       flash[:error] = "You are not authorized to delete sightings on this collection"
     end
@@ -67,7 +69,7 @@
   private
 
   def observation_params
-    params.require(:observation).permit(:description,:image, :collection_id).merge({curator_id: current_user.id})
+    params.require(:observation).permit(:description,:image, :collection_id)#.merge({curator_id: current_user.id})
   end
 
 end

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -19,6 +19,10 @@ class Observation < ActiveRecord::Base
     self.image_file_name.present?
   end
 
+  def owned_by?(user)
+    self.curator_id == user.id
+  end
+
 private
 
   def at_least_one


### PR DESCRIPTION
-Fix bug so that current user can now delete observations associated with someone else's collection.
-Fix bug so that approving an observation no longer changes its curator_id to the approver (so that original observation creator remains the curator of the observation, even though it is associated with another collection). 
